### PR TITLE
sort leader by name and distance

### DIFF
--- a/app/src/main/java/com/example/cyclofit/ui/firestore/FirestoreClass.kt
+++ b/app/src/main/java/com/example/cyclofit/ui/firestore/FirestoreClass.kt
@@ -15,6 +15,7 @@ import com.example.cyclofit.ui.activities.ProfileActivity
 import com.example.cyclofit.ui.activities.SettingsActivity
 import com.example.cyclofit.ui.fragment.*
 import com.example.cyclofit.ui.utils.Constants
+import com.example.cyclofit.ui.utils.Tools
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
@@ -507,6 +508,24 @@ class FirestoreClass {
             }
             .addOnFailureListener {
 
+            }
+    }
+
+    fun getLeaderboardFragment(lambda:(ArrayList<User>)->Unit) {
+        mFirestore.collection(Constants.USERS)
+            .get()
+            .addOnSuccessListener { document ->
+
+                val userList: ArrayList<User> = ArrayList()
+
+                for (i in document.documents) {
+                    val user = i.toObject(User::class.java)
+                    userList.add(user!!)
+                }
+                lambda(userList)
+            }
+            .addOnFailureListener {
+                Tools.debugMessage(message = it.message.toString(), tag = it.cause.toString())
             }
     }
 }

--- a/app/src/main/java/com/example/cyclofit/ui/fragment/LeaderboardFragment.kt
+++ b/app/src/main/java/com/example/cyclofit/ui/fragment/LeaderboardFragment.kt
@@ -1,10 +1,9 @@
 package com.example.cyclofit.ui.fragment
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.util.Log
+import android.view.*
+import androidx.core.view.MenuProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.cyclofit.R
 import com.example.cyclofit.databinding.FragmentLeaderboardBinding
@@ -12,36 +11,88 @@ import com.example.cyclofit.model.User
 import com.example.cyclofit.ui.adapter.LeaderboardAdapter
 import com.example.cyclofit.ui.firestore.FirestoreClass
 
+
 class LeaderboardFragment : BaseFragment() {
 
-    private lateinit var list : ArrayList<User>
+    private lateinit var list: ArrayList<User>
     private lateinit var binding: FragmentLeaderboardBinding
+    private lateinit var fireStoreManager: FirestoreClass
 
-    companion object{
-        var list=ArrayList<User>()
+    companion object {
+        var list = ArrayList<User>()
     }
+
+
+    private fun inflateMenuItem() {
+        // use menu provider api to implement menu
+        binding.toolbarDashboard.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                // Inflate the menu into the toolbar
+                menuInflater.inflate(R.menu.leaderboard_top, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                // check if any menu item is clicked
+                return when (menuItem.itemId) {
+                    R.id.refresh -> {
+                        // set menu item to its default state
+                        fireStoreManager.getLeaderboardFragment {
+                            getLeaderBoard(it)
+                        }
+                        true
+                    }
+                    R.id.id_menu_name -> {
+                        // arrange leader board item by name alphabetically(A-Z)
+                        fireStoreManager.getLeaderboardFragment {
+                            val userList = it.sortedBy { sort -> sort.name.lowercase() }
+                            val userArray: ArrayList<User> = ArrayList()
+                            userList.forEach { user ->
+                                userArray.add(user)
+                            }
+                            getLeaderBoard(userArray)
+                        }
+                        true
+                    }
+                    R.id.id_menu_distance -> {
+                        // arrange leader board item by distance (highest - lowest)
+                        fireStoreManager.getLeaderboardFragment {
+                            val userList = it.sortedByDescending { sort -> sort.distance.toDouble() }
+                            val userArray: ArrayList<User> = ArrayList()
+                            userList.forEach { user ->
+                                userArray.add(user)
+                            }
+                            getLeaderBoard(userArray)
+                        }
+                        true
+                    }
+                    else -> false
+                }
+            }
+        })
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
 
-        binding=FragmentLeaderboardBinding.inflate(inflater,container,false)
-        binding.toolbarDashboard.inflateMenu(R.menu.leaderboard_top)
+        binding = FragmentLeaderboardBinding.inflate(inflater, container, false)
         activity?.window!!.statusBarColor = requireActivity().getColor(R.color.dark_green)
+        fireStoreManager = FirestoreClass()
 
+        inflateMenuItem()
 
-         list=ArrayList<User>()
-        list.add(User("1","Pratyush","aries.@gmail.com","8.4"))
-        list.add(User("2","Ayush","aries.@gmail.com","7.2"))
-        list.add(User("3","Abhiram","aries.@gmail.com","6.8"))
-        list.add(User("4","Aditya","aries.@gmail.com","5.3"))
-        list.add(User("5","Samyak","aries.@gmail.com","5.1"))
-        list.add(User("6","Rahul","aries.@gmail.com","4.9"))
-        list.add(User("7","Ankur","aries.@gmail.com","3.0"))
-        list.add(User("8","Adiii","aries.@gmail.com","2.5"))
-        list.add(User("9","Prince","aries.@gmail.com","1.7"))
-        list.add(User("10","Ritik","aries.@gmail.com","0.8"))
-
+        list = ArrayList<User>()
+        list.add(User("1", "Pratyush", "aries.@gmail.com", "8.4"))
+        list.add(User("2", "Ayush", "aries.@gmail.com", "7.2"))
+        list.add(User("3", "Abhiram", "aries.@gmail.com", "6.8"))
+        list.add(User("4", "Aditya", "aries.@gmail.com", "5.3"))
+        list.add(User("5", "Samyak", "aries.@gmail.com", "5.1"))
+        list.add(User("6", "Rahul", "aries.@gmail.com", "4.9"))
+        list.add(User("7", "Ankur", "aries.@gmail.com", "3.0"))
+        list.add(User("8", "Adiii", "aries.@gmail.com", "2.5"))
+        list.add(User("9", "Prince", "aries.@gmail.com", "1.7"))
+        list.add(User("10", "Ritik", "aries.@gmail.com", "0.8"))
 
 
         return binding.root
@@ -51,13 +102,16 @@ class LeaderboardFragment : BaseFragment() {
 
         hideProgressDialog()
 
-        binding.rvLeaderboard.adapter=LeaderboardAdapter(requireContext(),userList)
-        binding.rvLeaderboard.layoutManager=LinearLayoutManager(activity,LinearLayoutManager.VERTICAL,false)
+        binding.rvLeaderboard.adapter = LeaderboardAdapter(requireContext(), userList)
+        binding.rvLeaderboard.layoutManager =
+            LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
     }
 
     override fun onResume() {
         super.onResume()
         showProgressDialog()
-        FirestoreClass().getLeaderboardFragment(this)
+        fireStoreManager.getLeaderboardFragment {
+            getLeaderBoard(it)
+        }
     }
 }

--- a/app/src/main/java/com/example/cyclofit/ui/utils/Tools.kt
+++ b/app/src/main/java/com/example/cyclofit/ui/utils/Tools.kt
@@ -1,0 +1,10 @@
+package com.example.cyclofit.ui.utils
+
+import android.util.Log
+
+object Tools {
+
+    fun debugMessage(message: String, tag: String = "DEBUG_MESSAGE") {
+        Log.e(tag, message)
+    }
+}

--- a/app/src/main/res/menu/leaderboard_top.xml
+++ b/app/src/main/res/menu/leaderboard_top.xml
@@ -3,5 +3,16 @@
     <item  android:id="@+id/refresh"
         android:title="Refresh"/>
     <item android:id="@+id/sort"
-        android:title="Sort"/>
+        android:title="Sort">
+        <menu>
+            <group>
+                <item
+                    android:id="@+id/id_menu_name"
+                    android:title="@string/sort_name"/>
+                <item
+                    android:id="@+id/id_menu_distance"
+                    android:title="@string/sort_distance"/>
+            </group>
+        </menu>
+    </item>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,11 +10,12 @@
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="DialogTitle">Choose Theme</string>
     <string name="climbuptxt">km away to climb up</string>
+    <string name="sort_name">by name</string>
+    <string name="sort_distance">by distance</string>
     <string-array name="DialogContents">
         <item>>White Theme</item>
         <item>Black Theme</item>
         <item>System Default</item>
-
     </string-array>
 
 </resources>


### PR DESCRIPTION
This is the fix for issue `Add option to sort the leaderboard on the basis of distance covered #4
`
I have completed the sorting by name(A-Z) and by distance (highest to lowest). 
The refresh doesn't do anything so I wrote the logic. When you click the refresh, it returns the list to the default state