### PR TITLE
leader board updated, sort by name and distance added

### DIFF
--- a/app/src/main/java/com/example/cyclofit/ui/firestore/FirestoreClass.kt
+++ b/app/src/main/java/com/example/cyclofit/ui/firestore/FirestoreClass.kt
@@ -15,6 +15,7 @@ import com.example.cyclofit.ui.activities.ProfileActivity
 import com.example.cyclofit.ui.activities.SettingsActivity
 import com.example.cyclofit.ui.fragment.*
 import com.example.cyclofit.ui.utils.Constants
+import com.example.cyclofit.ui.utils.Tools
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
@@ -507,6 +508,24 @@ class FirestoreClass {
             }
             .addOnFailureListener {
 
+            }
+    }
+
+    fun leaderBoarManager(lambda:(ArrayList<User>)->Unit){
+        mFirestore.collection(Constants.USERS)
+            .get()
+            .addOnSuccessListener { document ->
+
+                val userList: ArrayList<User> = ArrayList()
+
+                for (i in document.documents) {
+                    val user = i.toObject(User::class.java)
+                    userList.add(user!!)
+                }
+                lambda(userList)
+            }
+            .addOnFailureListener {
+                Tools.debugMessage(it.message.toString(), it.cause.toString())
             }
     }
 }

--- a/app/src/main/java/com/example/cyclofit/ui/fragment/LeaderboardFragment.kt
+++ b/app/src/main/java/com/example/cyclofit/ui/fragment/LeaderboardFragment.kt
@@ -1,10 +1,9 @@
 package com.example.cyclofit.ui.fragment
 
 import android.os.Bundle
+import android.view.*
 import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import androidx.core.view.MenuProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.cyclofit.R
 import com.example.cyclofit.databinding.FragmentLeaderboardBinding
@@ -14,35 +13,40 @@ import com.example.cyclofit.ui.firestore.FirestoreClass
 
 class LeaderboardFragment : BaseFragment() {
 
-    private lateinit var list : ArrayList<User>
+    private lateinit var list: ArrayList<User>
     private lateinit var binding: FragmentLeaderboardBinding
+    private lateinit var firestoreClass: FirestoreClass
 
-    companion object{
-        var list=ArrayList<User>()
+    companion object {
+        var list = ArrayList<User>()
     }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
 
-        binding=FragmentLeaderboardBinding.inflate(inflater,container,false)
-        binding.toolbarDashboard.inflateMenu(R.menu.leaderboard_top)
+        binding = FragmentLeaderboardBinding.inflate(inflater, container, false)
+        // binding.toolbarDashboard.inflateMenu(R.menu.leaderboard_top)
         activity?.window!!.statusBarColor = requireActivity().getColor(R.color.dark_green)
 
-
-         list=ArrayList<User>()
-        list.add(User("1","Pratyush","aries.@gmail.com","8.4"))
-        list.add(User("2","Ayush","aries.@gmail.com","7.2"))
-        list.add(User("3","Abhiram","aries.@gmail.com","6.8"))
-        list.add(User("4","Aditya","aries.@gmail.com","5.3"))
-        list.add(User("5","Samyak","aries.@gmail.com","5.1"))
-        list.add(User("6","Rahul","aries.@gmail.com","4.9"))
-        list.add(User("7","Ankur","aries.@gmail.com","3.0"))
-        list.add(User("8","Adiii","aries.@gmail.com","2.5"))
-        list.add(User("9","Prince","aries.@gmail.com","1.7"))
-        list.add(User("10","Ritik","aries.@gmail.com","0.8"))
+        firestoreClass = FirestoreClass()
 
 
+        list = ArrayList<User>()
+        list.add(User("1", "Pratyush", "aries.@gmail.com", "8.4"))
+        list.add(User("2", "Ayush", "aries.@gmail.com", "7.2"))
+        list.add(User("3", "Abhiram", "aries.@gmail.com", "6.8"))
+        list.add(User("4", "Aditya", "aries.@gmail.com", "5.3"))
+        list.add(User("5", "Samyak", "aries.@gmail.com", "5.1"))
+        list.add(User("6", "Rahul", "aries.@gmail.com", "4.9"))
+        list.add(User("7", "Ankur", "aries.@gmail.com", "3.0"))
+        list.add(User("8", "Adiii", "aries.@gmail.com", "2.5"))
+        list.add(User("9", "Prince", "aries.@gmail.com", "1.7"))
+        list.add(User("10", "Ritik", "aries.@gmail.com", "0.8"))
+
+
+        inflateMenuItem()
 
         return binding.root
     }
@@ -51,13 +55,56 @@ class LeaderboardFragment : BaseFragment() {
 
         hideProgressDialog()
 
-        binding.rvLeaderboard.adapter=LeaderboardAdapter(requireContext(),userList)
-        binding.rvLeaderboard.layoutManager=LinearLayoutManager(activity,LinearLayoutManager.VERTICAL,false)
+        binding.rvLeaderboard.adapter = LeaderboardAdapter(requireContext(), userList)
+        binding.rvLeaderboard.layoutManager =
+            LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
     }
 
     override fun onResume() {
         super.onResume()
         showProgressDialog()
-        FirestoreClass().getLeaderboardFragment(this)
+        firestoreClass.getLeaderboardFragment(this)
+    }
+
+    private fun inflateMenuItem() {
+        // use menu provider api to implement menu
+        binding.toolbarDashboard.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                // Inflate the menu into the toolbar
+                menuInflater.inflate(R.menu.leaderboard_top, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    R.id.refresh -> {
+                        firestoreClass.leaderBoarManager { userList->
+                            getLeaderBoard(userList)
+                        }
+                        true
+                    }
+                    R.id.id_menu_name -> {
+                        firestoreClass.leaderBoarManager { userList->
+                            val sortedArrList = ArrayList<User>()
+                            userList.sortedBy { it.name.lowercase() }.forEach {
+                                sortedArrList.add(it)
+                            }
+                            getLeaderBoard(sortedArrList)
+                        }
+                        true
+                    }
+                    R.id.id_menu_distance -> {
+                        firestoreClass.leaderBoarManager { userList->
+                            val sortedArrList = ArrayList<User>()
+                            userList.sortedByDescending { it.distance.toDouble() }.forEach {
+                                sortedArrList.add(it)
+                            }
+                            getLeaderBoard(sortedArrList)
+                        }
+                        true
+                    }
+                    else -> false
+                }
+            }
+        })
     }
 }

--- a/app/src/main/java/com/example/cyclofit/ui/utils/Tools.kt
+++ b/app/src/main/java/com/example/cyclofit/ui/utils/Tools.kt
@@ -1,0 +1,9 @@
+package com.example.cyclofit.ui.utils
+
+import android.util.Log
+
+object Tools {
+    fun debugMessage(message:String, tag:String = "DEBUG-MESSAGE"){
+        Log.e(tag, message)
+    }
+}

--- a/app/src/main/res/menu/leaderboard_top.xml
+++ b/app/src/main/res/menu/leaderboard_top.xml
@@ -3,5 +3,14 @@
     <item  android:id="@+id/refresh"
         android:title="Refresh"/>
     <item android:id="@+id/sort"
-        android:title="Sort"/>
+        android:title="Sort">
+        <menu>
+            <item
+                android:id="@+id/id_menu_name"
+                android:title="@string/by_name"/>
+            <item
+                android:id="@+id/id_menu_distance"
+                android:title="@string/by_distance"/>
+        </menu>
+    </item>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="DialogTitle">Choose Theme</string>
     <string name="climbuptxt">km away to climb up</string>
+    <string name="by_name">by name</string>
+    <string name="by_distance">by distance</string>
     <string-array name="DialogContents">
         <item>>White Theme</item>
         <item>Black Theme</item>

--- a/sort_leader_apk/output-metadata.json
+++ b/sort_leader_apk/output-metadata.json
@@ -1,0 +1,20 @@
+{
+  "version": 3,
+  "artifactType": {
+    "type": "APK",
+    "kind": "Directory"
+  },
+  "applicationId": "com.example.cyclofit",
+  "variantName": "debug",
+  "elements": [
+    {
+      "type": "SINGLE",
+      "filters": [],
+      "attributes": [],
+      "versionCode": 1,
+      "versionName": "1.0",
+      "outputFile": "app-debug.apk"
+    }
+  ],
+  "elementType": "File"
+}


### PR DESCRIPTION
I added the logic for the leaderboard menu item. The refresh menu item sort the leaderboard to its default list, The name menu item sort the leaderboard alphabetically (A-Z) while distance menu item sort the km according to highest km covered