### PR TITLE
fix: email text partially visible

### DIFF
--- a/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/app/src/main/res/layout/fragment_leaderboard.xml
@@ -118,7 +118,9 @@
                     android:layout_below="@+id/llUserName"
                     android:layout_marginLeft="10dp"
                     android:text="ashishgupta9936@gmail.com"
-                    android:textSize="17sp" />
+                    android:textSize="17sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"/>
 
 
             </RelativeLayout>


### PR DESCRIPTION
This PR resolved the issue of email text exceeding and not fully visible

Now The text ends with three dots.

Fixes #36

Screenshot
![Screenshot_2023-12-17-18-41-53-80_48d0ff434c8fef843eb6c6147ead4de5](https://github.com/PratyushSingh07/cyclofit/assets/40030547/3fa9e495-d3e0-4c17-93d6-7d5aa81dc511)
